### PR TITLE
Fix url to first-colo website in footer.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -515,7 +515,7 @@ LICENSE = """
 
 # A small copyright notice for the page footer (in HTML).
 # Default is ''
-CONTENT_FOOTER = '<div align="center"><small>Contents &copy; {date} <a href="mailto:{email}">{author}</a>. {license}<br/>Hosted by <a href="http://www.first-colo.net/EN/">First Colo</a></small></div>'
+CONTENT_FOOTER = '<div align="center"><small>Contents &copy; {date} <a href="mailto:{email}">{author}</a>. {license}<br/>Hosted by <a href="http://www.first-colo.com/">First Colo</a></small></div>'
 CONTENT_FOOTER = CONTENT_FOOTER.format(email=BLOG_EMAIL,
                                        author=BLOG_AUTHOR,
                                        date=time.gmtime().tm_year,


### PR DESCRIPTION
As advised by hpekdemir from the company.

```
<infirit> Which one?
<hpekdemir> the one on the bottom. "Hosted by First Colo"
<infirit> It points to http://www.first-colo.net/EN/ right now
<hpekdemir> this is First Colo. Hosting of mate-desktop.org. We changed our website, so the provided link on mate-desktop.org isn't up to date anymore. Please change to first-colo.com
<infirit> Ah ok I see
<infirit> hpekdemir, I'll look into it and correct it
```
