### PR TITLE
Add Parrot Security OS to Distributions List

### DIFF
--- a/pages/index.rst
+++ b/pages/index.rst
@@ -46,6 +46,7 @@ MATE is available via the **official** repositories for the following Linux dist
 * `Mageia <https://www.mageia.org/en/>`_
 * `Manjaro <http://manjaro.org/>`_
 * `openSUSE <http://www.opensuse.org>`_
+* `Parrot Security OS <http://www.parrotsec.org/>`_
 * `PCLinuxOS <http://www.pclinuxos.com/get-pclinuxos/mate/>`_
 * `PLD Linux <https://www.pld-linux.org/>`_
 * `Point Linux <http://pointlinux.org/>`_


### PR DESCRIPTION
Add Parrot Security OS to _Which distributions support MATE?_ section in index.rst 🐦