### PR TITLE
Update Solus URL

### DIFF
--- a/pages/index.de.rst
+++ b/pages/index.de.rst
@@ -58,7 +58,7 @@ erhältlich:
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.el.rst
+++ b/pages/index.el.rst
@@ -56,7 +56,7 @@ To Mate αναπτύσσεται ενεργά ώστε να υποστηρίζε
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.es.rst
+++ b/pages/index.es.rst
@@ -55,7 +55,7 @@ MATE está disponible a través de los repositorios **oficiales** de las siguien
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.fr.rst
+++ b/pages/index.fr.rst
@@ -57,7 +57,7 @@ MATE est disponible via les dépôts **officiels** des distributions GNU/Linux s
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.id.rst
+++ b/pages/index.id.rst
@@ -56,7 +56,7 @@ MATE tersedia melalui repositori **resmi** untuk distribusi Linux berikut:
 * `Point Linux <http://pointlinux.org>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org/>`_
 * `Vector Linux <http://vectorlinux.com/>`_

--- a/pages/index.it.rst
+++ b/pages/index.it.rst
@@ -56,7 +56,7 @@ MATE è disponibile tramite i repository **ufficiali** per le seguenti distribuz
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.pl.rst
+++ b/pages/index.pl.rst
@@ -58,7 +58,7 @@ Mate jest dostępne przez **oficjalne** repozytoria dla następujących dystrybu
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org/>`_
 * `Salix <http://www.salixos.org/>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com/>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org/>`_
 * `Vector Linux <http://vectorlinux.com/>`_

--- a/pages/index.pt.rst
+++ b/pages/index.pt.rst
@@ -53,7 +53,7 @@ Mate está disponível através dos repositórios **officiais** das distribuiç�
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.rst
+++ b/pages/index.rst
@@ -54,7 +54,7 @@ MATE is available via the **official** repositories for the following Linux dist
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.tr.rst
+++ b/pages/index.tr.rst
@@ -59,7 +59,7 @@ MATE aşağıdaki GNU/Linux dağıtımlarının **resmî** depolarında mevcuttu
 * `PLD Linux <https://www.pld-linux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Void Linux <http://www.voidlinux.eu/>`_

--- a/pages/index.zh_cn.rst
+++ b/pages/index.zh_cn.rst
@@ -55,7 +55,7 @@ MATE 在保持传统桌面体验的同时引入对新技术的支持。参见
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_

--- a/pages/index.zh_tw.rst
+++ b/pages/index.zh_tw.rst
@@ -58,7 +58,7 @@ MATE 在以下的 Linux 散佈版的 **官方** 套件庫中提供：
 * `Point Linux <http://pointlinux.org/>`_
 * `Sabayon <http://www.sabayon.org>`_
 * `Salix <http://www.salixos.org>`_
-* `Solus <https://solus-project.com/>`_
+* `Solus <https://getsol.us/>`_
 * `Ubuntu <http://www.ubuntu.com>`_
 * `Ubuntu MATE <http://www.ubuntu-mate.org>`_
 * `Vector Linux <http://vectorlinux.com>`_


### PR DESCRIPTION
Solus moved to another domain a few months ago (from `solus-project.com` to `getsol.us`).

Signed-off-by: Pierre-Yves <pyu@riseup.net>