### PR TITLE
Update license in the site footer. Closes #95

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1073,11 +1073,10 @@ LICENSE = ""
 # I recommend using the Creative Commons' wizard:
 # https://creativecommons.org/choose/
 LICENSE = """
-<a rel="license" href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
-<img alt="Creative Commons License BY-NC-SA"
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/3.0/">
+<img alt="Creative Commons License BY-SA"
 style="border-width:0; margin-bottom:12px;"
-src="https://i.creativecommons.org/l/by-nc-sa/4.0/88x31.png"></a>"""
-
+src="https://i.creativecommons.org/l/by-sa/3.0/88x31.png"></a>"""
 # A small copyright notice for the page footer (in HTML).
 # (translatable)
 CONTENT_FOOTER = 'Contents &copy; {date} <a href="mailto:{email}">{author}</a><br />{license}'


### PR DESCRIPTION
The site footer now correctly reflects the BY-SA license described in `LICENSE.md`.