### PR TITLE
Remove footer links to Google+ and the wiki.

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1538,11 +1538,8 @@ WARN_ABOUT_TAG_METADATA = False
 
 SOCIAL_ICONS="""
 <a class="social-icon" href="/rss.xml" title="MATE RSS feed"><img src="/assets/img/icons/rss.png" alt="RSS" class="small-margin"></a>
-<a class="social-icon" href="http://wiki.mate-desktop.com/" title="MATE Wiki"><img src="/assets/img/icons/wiki.png" alt="Wiki" class="small-margin"></a>
 <a class="social-icon" href="https://github.com/mate-desktop/" title="MATE GitHub"><img src="/assets/img/icons/github.png" alt="GitHub" class="small-margin"></a>
 <a class="social-icon" href="https://twitter.com/Mate_desktop" title="@Mate_Desktop Twitter"><img src="/assets/img/icons/twitter.png" alt="Twitter" class="small-margin"></a>
-<a class="social-icon" href="https://plus.google.com/u/0/communities/103904770310171205536" title="MATE Google+ Community"><img src="/assets/img/icons/gplus.png" alt="Google+" class="small-margin"></a>
-<a class="social-icon" href="https://plus.google.com/105251070079435964338/posts" title="MATE Google+ Page"><img src="/assets/img/icons/gplus.png" alt="Google+" class="small-margin"></a>
 """
 
 # Put in global_context things you want available on all your templates.


### PR DESCRIPTION
Google+ is being shut down next month so it's time to remove those links in the site footer. Also removed the footer links to the wiki.