### PR TITLE
Revert "Add missing css code for div.footerbox in mate.css"

### DIFF
--- a/files/assets/css/mate.css
+++ b/files/assets/css/mate.css
@@ -47,8 +47,3 @@ kbd {
 	-webkit-border-radius: 3px;
 	text-shadow: 0 1px 0 #fff;
 }
-
-div.footerbox {
-	text-align: center;
-	margin-bottom: 15px;
-}

--- a/themes/MATE/templates/base.tmpl
+++ b/themes/MATE/templates/base.tmpl
@@ -81,7 +81,7 @@ ${template_hooks['extra_head']()}
 
 <hr />
 
-<div class="footerbox">
+<div class="footerbox" align="center">
     ${content_footer}
     ${template_hooks['page_footer']()}
 


### PR DESCRIPTION
Reverts mate-desktop/mate-desktop.org#179

Broken webside
![Bildschirmfoto zu 2019-12-13 19-02-30](https://user-images.githubusercontent.com/961604/70825316-6a379d00-1de4-11ea-9b69-74c98faa8a0b.png)
