### PR TITLE
Community: Update forum links

### DIFF
--- a/pages/community.ca.md
+++ b/pages/community.ca.md
@@ -26,9 +26,10 @@ fòrums de la comunitat.
   * [Fòrums d'usuaris de Debian](http://forums.debian.net/)
   * [Fòrums de Fedora](https://fedoraforum.org/)
   * [Fòrums de Gentoo](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Fòrums de Linux Mint](https://forums.linuxmint.com/)
-  * [Fòrums d'Ubuntu MATE](https://ubuntu-mate.community)
   * [Subreddit de l'escriptori MATE](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Xarxes socials
 

--- a/pages/community.cs.md
+++ b/pages/community.cs.md
@@ -26,9 +26,10 @@ Pokud neposíláte e-maily, také tomu rozumíme. Přijďte se připojit na jedn
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Sociální média
 

--- a/pages/community.de.md
+++ b/pages/community.de.md
@@ -26,9 +26,10 @@ Sie mailen nicht -- verstehen wir auch.
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Soziale Medien
 

--- a/pages/community.es.md
+++ b/pages/community.es.md
@@ -26,9 +26,10 @@ No usas email, también lo entendemos. Ven y únete a uno de los foros comunitar
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Medios Sociales
 

--- a/pages/community.fr.md
+++ b/pages/community.fr.md
@@ -26,9 +26,10 @@ Vous n'utilisez pas le courrier électronique, nous le comprenons aussi.
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Réseau sociaux
 

--- a/pages/community.he.md
+++ b/pages/community.he.md
@@ -25,8 +25,9 @@
   * [פורום פדורה](https://fedoraforum.org/)
   * [הפורומים לדיונים של Gentoo](https://forums.gentoo.org/)
   * [הפורומים של לינוקס מינט](https://forums.linuxmint.com/)
-  * [הפורומים של MATE](https://ubuntu-mate.community)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [subreddit על שולחן העבודה MATE](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## רשתות חברתיות
 

--- a/pages/community.hu.md
+++ b/pages/community.hu.md
@@ -26,9 +26,10 @@ Ha nem szereti az e-mailt, megértjük. Jöjjön és csatlakozzon a közösségi
   * [Debian felhasználói fórum](http://forums.debian.net/)
   * [Fedora fórum](https://fedoraforum.org/)
   * [Gentoo fórum](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint fórum](https://forums.linuxmint.com/)
-  * [Ubuntu MATE fórum](https://ubuntu-mate.community)
   * [MATE asztali környezet subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Közösségi média
 

--- a/pages/community.id.md
+++ b/pages/community.id.md
@@ -26,9 +26,10 @@ Silahkan bergabung dengan forum komunitas kami.
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Media Sosial
 

--- a/pages/community.it.md
+++ b/pages/community.it.md
@@ -26,9 +26,10 @@ Se non usate l'email abbiamo pensato anche a questo. Unitevi ad uno dei nostri f
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Social Media
 

--- a/pages/community.ja.md
+++ b/pages/community.ja.md
@@ -23,9 +23,10 @@ MATE コミュニティと連携するには、さまざまな方法がありま
   * [Debian ユーザフォーラム](http://forums.debian.net/)
   * [Fedora フォーラム](https://fedoraforum.org/)
   * [Gentoo ディスカッション・フォーラム](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint フォーラム](https://forums.linuxmint.com/)
-  * [Ubuntu MATE フォーラム](https://ubuntu-mate.community)
   * [MATE デスクトップ subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## ソーシャルメディア
 

--- a/pages/community.md
+++ b/pages/community.md
@@ -26,9 +26,10 @@ You don't do email, we get that too. Come and join one of the community forums.
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Social Media
 

--- a/pages/community.nl.md
+++ b/pages/community.nl.md
@@ -26,9 +26,10 @@ Niet via email, dat snappen we. Hier kan je deel uitmaken van de community forum
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Social Media
 

--- a/pages/community.pl.md
+++ b/pages/community.pl.md
@@ -26,9 +26,10 @@ Jeśli nie przepadasz za listami, zajrzyj na fora naszych użytkowników:
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
   * [subreddit MATE Desktop](https://www.reddit.com/r/MATEDesktop)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Sieci społecznościowe
 

--- a/pages/community.ru.md
+++ b/pages/community.ru.md
@@ -26,9 +26,10 @@
   * [Форумы пользователей Debian](http://forums.debian.net/)
   * [Форум пользователей Fedora](https://fedoraforum.org/)
   * [Форумы для обсуждений Gentoo](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Форумы Linux Mint](https://forums.linuxmint.com/)
-  * [Форумы Ubuntu MATE](https://ubuntu-mate.community)
   * [MATE на Reddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Социальные сети
 

--- a/pages/community.sr.md
+++ b/pages/community.sr.md
@@ -26,9 +26,10 @@
   * [Форуми корисника Дебиана](http://forums.debian.net/)
   * [Форум Федоре](https://fedoraforum.org/)
   * [Форуми расправе о Џентуу](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Форуми Линукс Минта](https://forums.linuxmint.com/)
-  * [Форуми Убунту Мејта](https://ubuntu-mate.community)
   * [„subreddit“ Мејтове радне површи](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Друштвене мреже
 

--- a/pages/community.tr.md
+++ b/pages/community.tr.md
@@ -25,9 +25,10 @@ E-mail kullanmıyorsanız bu da bir sorun değildir.
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## Sosyal ağlar
 

--- a/pages/community.zh_cn.md
+++ b/pages/community.zh_cn.md
@@ -24,9 +24,10 @@
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## 社交媒体
 

--- a/pages/community.zh_tw.md
+++ b/pages/community.zh_tw.md
@@ -26,9 +26,10 @@
   * [Debian User Forums](http://forums.debian.net/)
   * [Fedora Forum](https://fedoraforum.org/)
   * [Gentoo Discussion Forums](https://forums.gentoo.org/)
+  * [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47)
   * [Linux Mint Forums](https://forums.linuxmint.com/)
-  * [Ubuntu MATE Forums](https://ubuntu-mate.community)
   * [MATE Desktop subreddit](https://www.reddit.com/r/MATEDesktop)
+  * [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191)
 
 ## 社群媒體
 


### PR DESCRIPTION
- Remove Ubuntu MATE Community, as it is being archived: https://ubuntu-mate.community/t/31342
- Add [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47), who have introduced a distro-agnostic MATE category.
- Add [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191) for completeness alongside other distros.