### PR TITLE
Update forum links

### DIFF
--- a/content/en/community/_index.md
+++ b/content/en/community/_index.md
@@ -27,11 +27,12 @@ Join us on Matrix at [#mate-desktop-environment:matrix.org](https://matrix.to/#/
 
 ## Forums
 
-Many distributions have dedicated MATE support forums:
+MATE support and discussions can be found in these forums:
 
-- [Ubuntu MATE Community](https://ubuntu-mate.community/)
+- [LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop)
 - [Linux Mint Forums](https://forums.linuxmint.com/viewforum.php?f=206)
 - [FreeBSD](https://forums.freebsd.org/tags/mate-desktop/)
+- [Ubuntu Discourse](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/)
 
 ## Events
 


### PR DESCRIPTION
- Drop Ubuntu MATE Community, as it is being archived: https://ubuntu-mate.community/t/31342. Replaced by an "Ubuntu MATE" category over on [Ubuntu Discourse.](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/)
- [Add LinuxCommunity.io](https://linuxcommunity.io/c/mate-desktop/47), which have a distro-agnostic MATE category.

Closes #744, which was a PR against the old website. 

~#744 originally proposed adding Ubuntu Discourse. While they do have an ["Ubuntu MATE" category](https://discourse.ubuntu.com/c/flavors/ubuntu-mate/191), it's not really a category intended for support, so I figured this shouldn't be carried over.~

The wording to introduce the forums was tweaked since the new **LinuxCommunity.io** link welcomes discussion, not just support.